### PR TITLE
feat: avoid selection on scroll using touch devices

### DIFF
--- a/plugins/MultiDrag/MultiDrag.js
+++ b/plugins/MultiDrag/MultiDrag.js
@@ -300,7 +300,7 @@ function MultiDragPlugin() {
 		drop({ originalEvent: evt, rootEl, parentEl, sortable, dispatchSortableEvent, oldIndex, putSortable }) {
 			let toSortable = (putSortable || this.sortable);
 
-			if (!evt) return;
+			if (!evt || parentEl === null) return;
 
 			let options = this.options,
 				children = parentEl.children;


### PR DESCRIPTION
Modifica eseguita per evitare di selezionare elementi mentre si scrolla con dispositivi touch.

Per fare in modo che la modifica funzioni è necessario aggiungere ilò codice codice:

```js
$(".sortable-class).on("scroll", function ( event ) {
    SORTABLE_OBJECT_LIST.forEach(
          function(item) {
            if (!DESTROYED && !$(".el.sortable-chosen").length) {
              item.destroy();
            }
          });
      DESTROYED = true;

    setTimeout(function() {
      sortable(); // applica sortable su tutle le liste 
      DESTROYED = false;
    }, 300);
  });
```
dove `SORTABLE_OBJECT_LIST` è la lista degli elementi sui quali è stato applicato sortable